### PR TITLE
Add props event (handling NOTIFICATION message)

### DIFF
--- a/src/yeelight.ts
+++ b/src/yeelight.ts
@@ -59,6 +59,9 @@ export class Yeelight extends EventEmitter {
         const commandId = "" + result.id;
         const originalCommand = this.sentCommands[commandId];
         if (!originalCommand) {
+            if (result.method === 'props') {
+                this.emit('props', result.params);
+            }
             return;
         }
         const eventData: IEventResult = {


### PR DESCRIPTION
Handle NOTIFICATION message (according to https://www.yeelight.com/download/Yeelight_Inter-Operation_Spec.pdf).
And emit 'props' event to get the latest state of the smart LED in time without having to poll the status from time to time.